### PR TITLE
encode manifest URI support for thorium web v1

### DIFF
--- a/prs/routes/api.py
+++ b/prs/routes/api.py
@@ -10,6 +10,7 @@
 import base64
 import requests
 import internetarchive as ia
+from urllib.parse import quote
 from fastapi import (
     APIRouter,
     Request,
@@ -58,9 +59,10 @@ async def apis(request: Request):
 async def get_manifest(request: Request, source: str, book_id: str):
     def patch_manifest(manifest):
         manifest_uri = f"{prs_uri(request)}/api/{source}/{book_id}/manifest.json"
+        encoded_manifest_uri = quote(manifest_uri, safe='')
         for i in range(len(manifest['links'])):
             if manifest['links'][i].get('rel') == 'self':
-                manifest['links'][i]['href'] = manifest_uri
+                manifest['links'][i]['href'] = encoded_manifest_uri
         return manifest
 
     # TODO: permission/auth checks go here, or decorate this route


### PR DESCRIPTION
closes #2 
This pull request updates the way manifest URLs are generated in the API to ensure they are properly URL-encoded. The most significant changes are:

Manifest URL encoding improvements:

* Added import of `quote` from `urllib.parse` in `prs/routes/api.py` to support URL encoding. which is needed for Thorium-web reader v1
* Updated the `patch_manifest` function in `get_manifest` to encode the `manifest_uri` using `quote`, ensuring the `href` for the manifest's self link is URL-safe.

